### PR TITLE
Fix properties access from ArcLauncher

### DIFF
--- a/arc-batch/pom.xml
+++ b/arc-batch/pom.xml
@@ -25,6 +25,13 @@
 					<exclude>prod/*.properties</exclude>
 				</excludes>
 			</resource>
+			
+			<resource>
+				<directory>src/main/WEB-INF</directory>
+				<includes>
+                    <include>**/*.xml</include>
+                </includes>
+			</resource>	
 		</resources>
 
 		<plugins>

--- a/arc-batch/src/main/WEB-INF/applicationContext.xml
+++ b/arc-batch/src/main/WEB-INF/applicationContext.xml
@@ -28,6 +28,7 @@
 			<list>
 				<value>classpath:fr/insee/config/app.properties
 				</value>
+				<value>${properties.path}</value>
 			</list>
 		</property>
 		<property name="ignoreUnresolvablePlaceholders" value="true" />

--- a/arc-batch/src/main/WEB-INF/applicationContext.xml
+++ b/arc-batch/src/main/WEB-INF/applicationContext.xml
@@ -21,10 +21,46 @@
 	<bean class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator"></bean>	
 		<bean class ="org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor"/>
 	 -->
+	 
+	 <bean id="propertyConfigurer"
+		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="locations">
+			<list>
+				<value>classpath:fr/insee/config/app.properties
+				</value>
+			</list>
+		</property>
+		<property name="ignoreUnresolvablePlaceholders" value="true" />
+		<property name="ignoreResourceNotFound" value="true" />
+	</bean>
  
-    <bean id="propertiesHandler" class="fr.insee.arc.utils.ressourceUtils.PropertiesHandler">
-        <property name="key1" value="${key1}"></property>
-        <property name="key2" value="${key2}"></property>
+    <bean id="properties" class="fr.insee.arc.utils.ressourceUtils.PropertiesHandler">
+        <property name="databasePoolName" value="${fr.insee.database.poolName}"></property>
+		<property name="databaseUrl" value="${fr.insee.database.arc.url}"></property>
+		<property name="databaseUsername" value="${fr.insee.database.arc.username}"></property>
+		<property name="databasePassword" value="${fr.insee.database.arc.password}"></property>
+		<property name="databaseDriverClassName" value="${fr.insee.database.arc.driverClassName}"></property>
+		<property name="ldapDirectoryUri" value="${fr.insee.annuaire.arc.uri}"></property>
+		<property name="ldapDirectoryIdent" value="${fr.insee.annuaire.arc.ident}"></property>
+		<property name="ldapDirectoryPassword" value="${fr.insee.annuaire.arc.password}"></property>
+		<property name="logPath" value="${fr.insee.arc.log.chemin}"></property>
+		<property name="logLevel" value="${fr.insee.arc.log.niveau}"></property>
+		<property name="logConfiguration" value="${fr.insee.arc.log.configuration}"></property>
+		<property name="batchArcEnvironment" value="${fr.insee.arc.batch.parametre.env}"></property>
+		<property name="batchExecutionEnvironment" value="${fr.insee.arc.batch.parametre.envExecution}"></property>
+		<property name="batchParametersDirectory" value="${fr.insee.arc.batch.parametre.repertoire}"></property>
+		<property name="threadsChargement" value="${fr.insee.arc.threads.chargement:1}"></property>
+		<property name="threadsNormage" value="${fr.insee.arc.threads.normage:1}"></property>
+		<property name="threadsControle" value="${fr.insee.arc.threads.controle:1}"></property>
+		<property name="threadsFiltrage" value="${fr.insee.arc.threads.filtrage:1}"></property>
+		<property name="threadsMapping" value="${fr.insee.arc.threads.mapping:1}"></property>
+		<property name="threadsRegle" value="${fr.insee.arc.threads.regle:1}"></property>
+		<property name="threadNombre" value="${fr.insee.arc.threads.nombre:1}"></property>
+		<property name="version" value="${fr.insee.arc.version}"></property>
+		<property name="isProd" value="${fr.insee.plateforme.prod:false}"></property>
+		<property name="application" value="${fr.insee.application:ARC}"></property>
+		<property name="schemaReference" value="${fr.insee.arc.schema.reference}"></property>
+		<property name="rootDirectory" value="${fr.insee.arc.repertoire.root}"></property>
     </bean>
 
 </beans>

--- a/arc-batch/src/main/java/fr/insee/arc/batch/ARCLauncher.java
+++ b/arc-batch/src/main/java/fr/insee/arc/batch/ARCLauncher.java
@@ -232,7 +232,7 @@ public class ARCLauncher implements IReturnCode {
 	public static void main(String[] args) {
 
 		boolean remainingFile = false;
-		PropertiesHandler properties = new PropertiesHandler();
+		PropertiesHandler properties = PropertiesHandler.getInstance();
 
 		do {
 

--- a/arc-batch/src/main/resources/fr/insee/config/app.properties
+++ b/arc-batch/src/main/resources/fr/insee/config/app.properties
@@ -14,9 +14,9 @@ fr.insee.arc.environnement.is.dev=false
 
 ## ARC-DEV depuis eclipse
 fr.insee.database.poolName=arc
-fr.insee.database.arc.url=***REMOVED***
-fr.insee.database.arc.username=***REMOVED***
-fr.insee.database.arc.password=***REMOVED***
+fr.insee.database.arc.url=${env.urlDatabase}
+fr.insee.database.arc.username=${env.usernameDatabase}
+fr.insee.database.arc.password=${env.passwordDatabase}
 fr.insee.database.arc.driverClassName=org.postgresql.Driver
 fr.insee.database.arc.schema=arc
 
@@ -67,10 +67,10 @@ fr.insee.database.arc.schema=arc
 
 ## log4j
 ## Chemin vers le r�pertoire o� seront stock�es les logs
-fr.insee.dsn.log.chemin=***REMOVED***
+fr.insee.arc.log.chemin=${env.logPath}
 ## Niveau de journalisation : ALL < TRACE < DEBUG < INFO < WARN < ERROR < FATAL < OFF
-fr.insee.dsn.log.niveau=ERROR
-fr.insee.dsn.log.configuration=***REMOVED***
+fr.insee.arc.log.niveau=${env.logLevel}
+fr.insee.arc.log.configuration=${env.logSettings}
 
 fr.insee.arc.batch.parametre.env=arc.ihm
 fr.insee.arc.batch.parametre.envExecution=arc.bas8


### PR DESCRIPTION
When trying to launch the batch independently from ArcLauncher, the properties were not correctly picked up by the PropertyHandler class.
This fixes it by :
- adding applicationContext.xml to the build path
- configuring applicationContext.xml for the PropertyHandler class
- using getInstance() instead of a simple constructor to access PropertyHandler
- fixing some properties names