### PR TITLE
Adds some minor changes from the internal Insee application

### DIFF
--- a/arc-web/src/main/java/fr/insee/arc/web/action/GererFamilleNormeAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/GererFamilleNormeAction.java
@@ -25,7 +25,9 @@ import fr.insee.arc.web.model.ViewFamilleNorme;
 import fr.insee.arc.web.model.ViewTableMetier;
 import fr.insee.arc.web.model.ViewVariableMetier;
 import fr.insee.arc.web.util.VObject;
+import fr.insee.arc.web.util.ArcStringUtils;
 import fr.insee.arc.web.util.ConstantVObject.ColumnRendering;
+import fr.insee.arc.web.util.LineObject;
 
 @Component
 @Results({ @Result(name = "success", location = "/jsp/gererFamilleNorme.jsp"), @Result(name = "index", location = "/jsp/index.jsp") })
@@ -353,6 +355,11 @@ public class GererFamilleNormeAction extends ArcAction {
 
 	    HashMap<String, ArrayList<String>> mBefore = this.viewVariableMetier.mapSameContentFromPreviousVObject();
 	    List<ArrayList<String>> lBefore = this.viewVariableMetier.listSameContentFromPreviousVObject();
+	    
+	    for (LineObject line : this.viewVariableMetier.getContent().getLines()) {
+	    	int indexOfVar = this.viewVariableMetier.getDatabaseColumnsLabel().indexOf("nom_variable_metier");
+	    	line.getData().set(indexOfVar, ArcStringUtils.cleanUpVariable(line.getData().get(indexOfVar)));
+	    }
 
 	    HashMap<String, ArrayList<String>> mAfter = this.viewVariableMetier.mapSameContentFromCurrentVObject();
 	    List<ArrayList<String>> lAfter = this.viewVariableMetier.listSameContentFromCurrentVObject();
@@ -454,6 +461,9 @@ public class GererFamilleNormeAction extends ArcAction {
                 	
                 	// au moins une table est resnseignée
                 	blank=false;
+
+                	String nomVariableMetier = this.viewVariableMetier.getInputFieldFor("nom_variable_metier");
+                    this.viewVariableMetier.setInputFieldFor("nom_variable_metier", ArcStringUtils.cleanUpVariable(nomVariableMetier));
                 	
                     if (checkIsValide(this.viewVariableMetier.getInputFields())) {
                         requete.append("INSERT INTO arc."+IHM_MOD_VARIABLE_METIER+" (");
@@ -727,7 +737,7 @@ public class GererFamilleNormeAction extends ArcAction {
 
 //	            String nomFamille = mapContentAfterUpdate.get("id_famille").get(i);
 //            Set <String> keys=mapContentAfterUpdate.keySet();
-//            
+//
 //            for (String s:keys)
 //            {
 //            	if (!s.equals("id_famille")
@@ -737,21 +747,21 @@ public class GererFamilleNormeAction extends ArcAction {
 //            			&& !s.equals("type_consolidation")
 //            			)
 //            	{
-//                    
-//                    String nomTableCourt = 
+//
+//                    String nomTableCourt =
 //                    		ManipString.substringAfterFirst(ManipString.substringBeforeLast(s,underscore),underscore)
 //                    		.substring(nomFamille.length()+1)
 //                    		;
-//                    
-//                    
-//                    
+//
+//
+//
 //                    if (nomVariable.equals("id_"+nomTableCourt) && !typeConsolidation.equalsIgnoreCase("{exclus}")) {
 //                        message.append("La variable identifiante technique " + nomVariable + " doit avoir type_consolidation = \"{exclus}\".");
 //                        return false;
 //                    }
-//            		
+//
 //            	}
-//            		
+//
 //            }
             
             

--- a/arc-web/src/main/java/fr/insee/arc/web/action/PilotageBAS8Action.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/PilotageBAS8Action.java
@@ -102,7 +102,7 @@ public class PilotageBAS8Action extends ArcAction {
 	public void initializePilotageBAS8() {
 		LoggerHelper.debug(LOGGER, "* initializePilotageBAS8 *");
 		HashMap<String, String> defaultInputFields = new HashMap<>();
-		StringBuilder requete = FormatSQL.getAllReccordsFromATableDescOrder(
+		StringBuilder requete = FormatSQL.getAllReccordsFromATableAscOrder(
 				getBddTable().getQualifedName(BddTable.ID_TABLE_PILOTAGE_FICHIER_T), "date_entree");
 
 		this.viewPilotageBAS8.initialize(requete.toString(),
@@ -148,6 +148,7 @@ public class PilotageBAS8Action extends ArcAction {
 		requete.append("from " + getBddTable().getQualifedName(BddTable.ID_TABLE_PILOTAGE_FICHIER));
 		requete.append(" where rapport is not null ");
 		requete.append("group by date_entree, phase_traitement, etat_traitement, rapport ");
+		requete.append("order by date_entree asc ");
 		this.viewRapportBAS8.initialize(requete.toString(), null, defaultInputFields);
 	}
 

--- a/arc-web/src/main/java/fr/insee/arc/web/action/PilotageBAS8Action.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/PilotageBAS8Action.java
@@ -733,7 +733,7 @@ public class PilotageBAS8Action extends ArcAction {
 		try {
 
 			UtilitaireDao.get("arc").executeImmediate(null, updateToDelete);
-			message = "Fichier(s) à rejoués(s)";
+			message = "Fichier(s) à rejouer";
 		} catch (SQLException e) {
 			LoggerDispatcher
 					.info("Problème lors de la mise à jour de to_delete dans la table pilotage_fichier, requete :  "
@@ -796,7 +796,7 @@ public class PilotageBAS8Action extends ArcAction {
 		try {
 
 			UtilitaireDao.get("arc").executeImmediate(null, updateToDelete);
-			message = "Archives(s) à rejoués(s)";
+			message = "Archives(s) à rejouer";
 		} catch (SQLException e) {
 			LoggerDispatcher
 					.info("Problème lors de la mise à jour de to_delete dans la table pilotage_fichier, requete :  "

--- a/arc-web/src/main/java/fr/insee/arc/web/action/PilotagePRODAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/PilotagePRODAction.java
@@ -933,7 +933,7 @@ public class PilotagePRODAction implements SessionAware {
 
             UtilitaireDao.get("arc").executeImmediate(null, updateToDelete);
 			AbstractPhaseService.startProductionInitialization();
-            message = "Archives(s) à rejoués(s)";
+            message = "Archives(s) à rejouer";
         } catch (SQLException e) {
             LoggerDispatcher
                     .info("Problème lors de la mise à jour de to_delete dans la table pilotage_fichier, requete :  " + updateToDelete, logger);

--- a/arc-web/src/main/java/fr/insee/arc/web/action/PilotagePRODAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/PilotagePRODAction.java
@@ -164,7 +164,7 @@ public class PilotagePRODAction implements SessionAware {
         System.out.println("/* initializePilotagePROD */");
         HashMap<String, String> defaultInputFields = new HashMap<String, String>();
         StringBuilder requete = new StringBuilder();
-        requete.append("select * from "+AbstractPhaseService.dbEnv(this.envExecution)+"pilotage_fichier_t order by date_entree desc");
+        requete.append("select * from "+AbstractPhaseService.dbEnv(this.envExecution)+"pilotage_fichier_t order by date_entree asc");
 
         // this.viewPilotagePROD.setColumnRendering(ArcConstantVObjectGetter.columnRender.get(this.viewPilotagePROD.getSessionName()));
         this.viewPilotagePROD.initialize(requete.toString(), null, defaultInputFields);
@@ -191,6 +191,7 @@ public class PilotagePRODAction implements SessionAware {
         requete.append("from "+AbstractPhaseService.dbEnv(this.envExecution)+"pilotage_fichier ");
         requete.append("where rapport is not null ");
         requete.append("group by date_entree, phase_traitement, etat_traitement, rapport ");
+        requete.append("order by date_entree asc ");
         // this.viewRapportPROD.setColumnRendering(ArcConstantVObjectGetter.columnRender.get(this.viewRapportPROD.getSessionName()));
         this.viewRapportPROD.initialize(requete.toString(), null, defaultInputFields);
     }
@@ -378,7 +379,7 @@ public class PilotagePRODAction implements SessionAware {
 		} catch (SQLException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}    	
+		}
         return sessionSyncronize();
     }
 
@@ -393,7 +394,7 @@ public class PilotagePRODAction implements SessionAware {
 		} catch (SQLException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
-		}    	
+		}
         return sessionSyncronize();
     }
     

--- a/arc-web/src/main/java/fr/insee/arc/web/model/ViewRapportPROD.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/model/ViewRapportPROD.java
@@ -20,7 +20,7 @@ public class ViewRapportPROD  extends VObject {
                 put("phase_traitement", new ColumnRendering(true, "Phase", "90px", "text", null, true));
                 put("etat_traitement", new ColumnRendering(true, "Etat", "60px", "text", null, true));
                 put("rapport", new ColumnRendering(true, "Rapport d'anomalie", "200px", "text", null, true));
-                put("nb", new ColumnRendering(true, "Nombre de fichier", "55px", "text", null, true));
+                put("nb", new ColumnRendering(true, "Nombre de fichiers", "55px", "text", null, true));
             
             }
         }

--- a/arc-web/src/main/java/fr/insee/arc/web/util/ArcStringUtils.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/util/ArcStringUtils.java
@@ -1,0 +1,20 @@
+package fr.insee.arc.web.util;
+
+import java.util.Locale;
+
+public class ArcStringUtils {
+
+	private ArcStringUtils() {
+		// Classe statique non instantiable
+	}
+
+	/** Cleans up a business variable for ARC : lowercase and trim.
+	 * Returns null in the variable is null.*/
+	public static String cleanUpVariable(String variable) {
+		if (variable == null) {
+			return null;
+		}
+		return variable.trim().toLowerCase(Locale.FRANCE);
+	}
+
+}

--- a/arc-web/src/main/java/fr/insee/arc/web/util/VObject.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/util/VObject.java
@@ -1313,6 +1313,30 @@ public class VObject {
 	return new GenericBean(v0.databaseColumnsLabel, v0.databaseColumnsType, listInputFields()).mapContent();
     }
 
+    /** Set the input value for the specified column.
+     * @param headerDLabel column name in database
+     * @param value new value
+     * @throw IllegalArgumentException if the column name is invalid */
+    public void setInputFieldFor(String headerDLabel, String value) {
+    	int index = databaseColumnsLabel.indexOf(headerDLabel);
+    	if (index == -1) {
+    		throw new IllegalArgumentException("Column " + headerDLabel + " not found.");
+    	}
+    	inputFields.set(index, value);
+    }
+
+    /** Return the input value for the specified column.
+     * Syntaxic sugar for mapInputFields().get("my_column").get(0).
+     * @param headerDLabel column name in database
+     * @throw IllegalArgumentException if the column name is invalid */
+    public String getInputFieldFor(String headerDLabel) {
+    	int index = databaseColumnsLabel.indexOf(headerDLabel);
+    	if (index == -1) {
+    		throw new IllegalArgumentException("Column " + headerDLabel + " not found.");
+    	}
+    	return mapInputFields().get(headerDLabel).get(0);
+    }
+    
     public ArrayList<ArrayList<String>> listLineContent(int i) {
 	ArrayList<ArrayList<String>> r = new ArrayList<ArrayList<String>>();
 	r.add(new ArrayList<String>(this.content.get(i).getData()));

--- a/arc-web/src/main/resources/global_fr.properties
+++ b/arc-web/src/main/resources/global_fr.properties
@@ -92,7 +92,7 @@ label.step.error=Erreur en %
 label.date.processing=Date de traitement
 label.step.report=Rapport
 label.step.count.line=Nb obs
-label.step.count.file=Nombre de fichier
+label.step.count.file=Nombre de fichiers
 label.step.todo=A faire
 label.step.XML=Jointure XML
 
@@ -108,7 +108,7 @@ view.mapping=R\u00e8gles de mapping
 
 view.envManagement=Etat des fichiers dans le traitement
 view.envManagement.report=Rapport de traitement
-view.envManagement.detail=Détail des fichiers traités
+view.envManagement.detail=Dï¿½tail des fichiers traitï¿½s
 
 view.family=Liste des familles de normes
 view.client.softwares=Applications clientes

--- a/arc-web/src/main/webapp/jsp/gererFamilleNorme.jsp
+++ b/arc-web/src/main/webapp/jsp/gererFamilleNorme.jsp
@@ -127,6 +127,9 @@
 							<s:param name="btnDelete">true</s:param>
 							<s:param name="checkbox">true</s:param>
 							<s:param name="checkboxVisible">true</s:param>
+							<s:param name="extraScopeAdd">viewVariableMetier;</s:param>
+							<s:param name="extraScopeUpdate">viewVariableMetier;</s:param>
+							<s:param name="extraScopeDelete">viewVariableMetier;</s:param>
 						</s:include>
 					</div>
 				</div>

--- a/arc-web/src/test/java/fr/insee/arc/web/util/ArcStringUtilsTest.java
+++ b/arc-web/src/test/java/fr/insee/arc/web/util/ArcStringUtilsTest.java
@@ -1,0 +1,25 @@
+package fr.insee.arc.web.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ArcStringUtilsTest {
+
+	//cleanUpVariable(String)
+	@Test
+	public void variableIsCleaned() {
+		assertEquals("toto", ArcStringUtils.cleanUpVariable(" ToTo "));
+	}
+
+	@Test
+	public void cleanVariableIsIdentical() {
+		assertEquals("toto", ArcStringUtils.cleanUpVariable("toto"));
+	}
+
+	@Test
+	public void nulllVariableIsIgnored() {
+		assertEquals(null, ArcStringUtils.cleanUpVariable(null));
+	}
+	
+}


### PR DESCRIPTION
Adds some minor changes to the web application from changes made to the internal Insee version of ARC : 
- typo fixes
- cleans up data model field names (trim&lowercase) before inserting/updating them
- orders by default report table by reverse entry date

Also fixes a minor bug in this version : updates the data model field table in selectFamilleNorme when a model table is added, modified or deleted.