### PR TITLE
Fix output directory in selectFile action

### DIFF
--- a/arc-web/src/main/java/fr/insee/arc/web/action/GererFileAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/GererFileAction.java
@@ -293,7 +293,7 @@ public class GererFileAction implements SessionAware, ICharacterConstant {
 
         if (this.dirOut==null)
         {
-            this.dirIn=PROPERTIES.getRootDirectory();
+            this.dirOut=PROPERTIES.getRootDirectory();
         }
 
         ArrayList<ArrayList<String>> listeFichier = getFilesFromDirectory(this.dirOut, this.viewDirOut.mapFilterFields());

--- a/arc-web/src/main/java/fr/insee/arc/web/action/GererFileAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/GererFileAction.java
@@ -469,7 +469,10 @@ public class GererFileAction implements SessionAware, ICharacterConstant {
         }
         return sessionSyncronize();
     }
-
+    
+    public VObject getViewDirOut() {
+		return viewDirOut;
+	}
 
     public ArrayList<ArrayList<String>> getFilesFromDirectory(String dir, HashMap<String,ArrayList<String>> filter2)
     {
@@ -582,5 +585,8 @@ public class GererFileAction implements SessionAware, ICharacterConstant {
 
     }
 
+    public void setScope(String scope) {
+		this.scope = scope;
+	}
 
 }

--- a/arc-web/src/main/webapp/jsp/gererFile.jsp
+++ b/arc-web/src/main/webapp/jsp/gererFile.jsp
@@ -203,7 +203,7 @@
             <div class="bandeau">
               <s:property value="%{viewDirOut.title}" />
             </div>
-            <s:hidden name="viewDirOut.headerSortDLabel" value="" />
+            <s:hidden name="viewDirOut.databaseColumnsSort" value="" />
             <table class="fixedHeader" style="table-layout:auto; width:100%;">
               <thead>
                 <tr>


### PR DESCRIPTION
This fixes a few issues with the selectFile action in the web application:
* the output directory was not properly initialized to the default root, resulting in an error when trying to access the page
* the output directory was not visible on the page (missing getter)
* the scope setter was missing