### PR TITLE
Fix multiple bugs/issues in selectNorme

### DIFF
--- a/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
@@ -806,6 +806,33 @@ public class GererNormeAction extends ArcAction {
     }
 
     /**
+     * Clean the loading rules. Update GUI and database
+     * 
+     * @return
+     */
+    @Action(value = "/viderChargement")
+    public String viderChargement() {
+	initialize();
+	NormManagementDao.emptyRuleTable(this.viewRulesSet,
+		getBddTable().getQualifedName(BddTable.ID_TABLE_IHM_CHARGEMENT_REGLE));
+	return generateDisplay();
+    }
+    
+    /**
+     * Clean the structure rules. Update GUI and database
+     * 
+     * @return
+     */
+    @Action(value = "/viderNormage")
+    public String viderNormage() {
+	initialize();
+	NormManagementDao.emptyRuleTable(this.viewRulesSet,
+		getBddTable().getQualifedName(BddTable.ID_TABLE_IHM_NORMAGE_REGLE));
+	return generateDisplay();
+    }
+    
+    
+    /**
      * Clean the control rules. Update GUI and database
      * 
      * @return

--- a/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
@@ -939,7 +939,7 @@ public class GererNormeAction extends ArcAction {
     @Action(value = "/importFiltrage")
     public String importFiltrage() {
 	initialize();
-	NormManagementDao.uploadFileRule(this.viewFiltrage, this.viewRulesSet, this.fileUploadLoad);
+	NormManagementDao.uploadFileRule(this.viewFiltrage, this.viewRulesSet, this.fileUploadFilter);
 	return generateDisplay();
     }
 

--- a/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
@@ -1238,6 +1238,7 @@ public class GererNormeAction extends ArcAction {
 			, ConstanteBD.VERSION.getValue()//
 			, ConstanteBD.ID_CLASS.getValue()//
 			, ConstanteBD.RUBRIQUE_NMCL.getValue()//
+			, ConstanteBD.ID_REGLE.getValue()//
 			, ConstanteBD.COMMENTAIRE.getValue()));
 
 		requete.append(")");
@@ -1249,6 +1250,7 @@ public class GererNormeAction extends ArcAction {
 			, "'" + selectionOut.get(ConstanteBD.VERSION.getValue()).get(0) + "'"//
 			, ConstanteBD.ID_CLASS.getValue()//
 			, ConstanteBD.RUBRIQUE_NMCL.getValue()//
+			, ConstanteBD.ID_REGLE.getValue()//
 			, ConstanteBD.COMMENTAIRE.getValue()));
 
 	    } else if (this.getSelectedJeuDeRegle().equals("arc.ihm_controle_regle")) {

--- a/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/action/GererNormeAction.java
@@ -1300,8 +1300,8 @@ public class GererNormeAction extends ArcAction {
 			, ConstanteBD.VALIDITE_INF.getValue()//
 			, ConstanteBD.VALIDITE_SUP.getValue()//
 			, ConstanteBD.VERSION.getValue()//
-			, ConstanteBD.PERIODICITE.getValue()//
-			, ConstanteBD.EXPR_REGLE_FILTRE.getValue()));
+			, ConstanteBD.EXPR_REGLE_FILTRE.getValue()//
+			, ConstanteBD.COMMENTAIRE.getValue()));
 
 		requete.append(")");
 

--- a/arc-web/src/main/java/fr/insee/arc/web/model/ViewJeuxDeReglesCopie.java
+++ b/arc-web/src/main/java/fr/insee/arc/web/model/ViewJeuxDeReglesCopie.java
@@ -9,6 +9,9 @@ import fr.insee.arc.web.util.ConstantVObject.ColumnRendering;
 public class ViewJeuxDeReglesCopie extends VObject {
     public ViewJeuxDeReglesCopie() {
         super();
+        
+        this.setTitle("normManagement.copyRules");
+
         this.constantVObject = new ConstantVObject(new HashMap<String, ColumnRendering>() {
             /**
 			 * 
@@ -16,12 +19,12 @@ public class ViewJeuxDeReglesCopie extends VObject {
             private static final long serialVersionUID = 7482785414572296062L;
 
 			{
-                put("id_norme", new ColumnRendering(true, "Norme", "100px", "text", null, false));
-                put("periodicite", new ColumnRendering(true, "Periodicite", "100px", "text", null, false));
-                put("validite_inf", new ColumnRendering(true, "Debut Validite", "100px", "text", null, false));
-                put("validite_sup", new ColumnRendering(true, "Fin Validite", "100px", "text", null, false));
-                put("version", new ColumnRendering(true, "Version", "50px", "text", null, false));
-                put("etat", new ColumnRendering(true, "Statut", "120px", "select", "select id, val from arc.ext_etat_jeuderegle order by id", false));
+                put("id_norme", new ColumnRendering(true, "label.norm", "100px", "text", null, false));
+                put("periodicite", new ColumnRendering(true, "label.periodicity", "100px", "text", null, false));
+                put("validite_inf", new ColumnRendering(true, "label.validity.min", "100px", "text", null, false));
+                put("validite_sup", new ColumnRendering(true, "label.validity.max", "100px", "text", null, false));
+                put("version", new ColumnRendering(true, "label.version", "50px", "text", null, false));
+                put("etat", new ColumnRendering(true, "label.state", "120px", "select", "select id, val from arc.ext_etat_jeuderegle order by id", false));
 
             }
 

--- a/arc-web/src/main/resources/global.properties
+++ b/arc-web/src/main/resources/global.properties
@@ -35,6 +35,7 @@ gui.button.sort=Sort
 gui.button.add=Add
 gui.button.update=Update
 gui.button.delete=Delete
+gui.button.copy=Copy
 
 gui.button.deleteRuleset=Delete this ruleset
 gui.button.replaceRuleset=Replace this ruleset

--- a/arc-web/src/main/resources/global.properties
+++ b/arc-web/src/main/resources/global.properties
@@ -27,7 +27,7 @@ normManagement.structurize=Structurize
 normManagement.control=Control
 normManagement.filter=Filter
 normManagement.mapmodel=Map model
-normManagement.copyRules=Rule set to copy
+normManagement.copyRules=Rulesets for copy
 
 gui.button.refresh=Refresh
 gui.button.see=See

--- a/arc-web/src/main/resources/global.properties
+++ b/arc-web/src/main/resources/global.properties
@@ -40,6 +40,7 @@ gui.button.copy=Copy
 gui.button.deleteRuleset=Delete this ruleset
 gui.button.replaceRuleset=Replace this ruleset
 gui.button.generateRuleset=Generate a ruleset
+gui.button.downloadRuleset=Download this ruleset
 
 gui.button.downloadDatabase=Download data
 gui.button.downloadFile=Download file

--- a/arc-web/src/main/resources/global.properties
+++ b/arc-web/src/main/resources/global.properties
@@ -41,6 +41,7 @@ gui.button.deleteRuleset=Delete this ruleset
 gui.button.replaceRuleset=Replace this ruleset
 gui.button.generateRuleset=Generate a ruleset
 gui.button.downloadRuleset=Download this ruleset
+gui.button.importRuleset=Import ruleset
 
 gui.button.downloadDatabase=Download data
 gui.button.downloadFile=Download file

--- a/arc-web/src/main/resources/global_en.properties
+++ b/arc-web/src/main/resources/global_en.properties
@@ -35,6 +35,7 @@ gui.button.sort=Sort
 gui.button.add=Add
 gui.button.update=Update
 gui.button.delete=Delete
+gui.button.copy=Copy
 
 gui.button.deleteRuleset=Delete this ruleset
 gui.button.replaceRuleset=Replace this ruleset

--- a/arc-web/src/main/resources/global_en.properties
+++ b/arc-web/src/main/resources/global_en.properties
@@ -27,7 +27,7 @@ normManagement.structurize=Structurize
 normManagement.control=Control
 normManagement.filter=Filter
 normManagement.mapmodel=Map model
-normManagement.copyRules=Rule set to copy
+normManagement.copyRules=Rulesets for copy
 
 gui.button.refresh=Refresh
 gui.button.see=See

--- a/arc-web/src/main/resources/global_en.properties
+++ b/arc-web/src/main/resources/global_en.properties
@@ -40,6 +40,7 @@ gui.button.copy=Copy
 gui.button.deleteRuleset=Delete this ruleset
 gui.button.replaceRuleset=Replace this ruleset
 gui.button.generateRuleset=Generate a ruleset
+gui.button.downloadRuleset=Download this ruleset
 
 gui.button.downloadDatabase=Download data
 gui.button.downloadFile=Download file

--- a/arc-web/src/main/resources/global_en.properties
+++ b/arc-web/src/main/resources/global_en.properties
@@ -41,6 +41,7 @@ gui.button.deleteRuleset=Delete this ruleset
 gui.button.replaceRuleset=Replace this ruleset
 gui.button.generateRuleset=Generate a ruleset
 gui.button.downloadRuleset=Download this ruleset
+gui.button.importRuleset=Import ruleset
 
 gui.button.downloadDatabase=Download data
 gui.button.downloadFile=Download file

--- a/arc-web/src/main/resources/global_fr.properties
+++ b/arc-web/src/main/resources/global_fr.properties
@@ -41,6 +41,7 @@ gui.button.deleteRuleset=Effacer ce jeu de r\u00e8gle
 gui.button.replaceRuleset=Remplacer ce jeu de r\u00e8gle
 gui.button.generateRuleset=Pr\u00e9-g\u00e9n\u00e9rer les r\u00e8gles
 gui.button.downloadRuleset=T\u00e9l\u00e9charger les r\u00e8gles
+gui.button.importRuleset=Importer un jeu de r\u00e8gles
 
 gui.button.downloadDatabase=T\u00e9l\u00e9charger DB
 gui.button.downloadFile=T\u00e9l\u00e9charger fichier

--- a/arc-web/src/main/resources/global_fr.properties
+++ b/arc-web/src/main/resources/global_fr.properties
@@ -40,6 +40,7 @@ gui.button.copy=Copier
 gui.button.deleteRuleset=Effacer ce jeu de r\u00e8gle
 gui.button.replaceRuleset=Remplacer ce jeu de r\u00e8gle
 gui.button.generateRuleset=Pr\u00e9-g\u00e9n\u00e9rer les r\u00e8gles
+gui.button.downloadRuleset=T\u00e9l\u00e9charger les r\u00e8gles
 
 gui.button.downloadDatabase=T\u00e9l\u00e9charger DB
 gui.button.downloadFile=T\u00e9l\u00e9charger fichier

--- a/arc-web/src/main/resources/global_fr.properties
+++ b/arc-web/src/main/resources/global_fr.properties
@@ -35,6 +35,7 @@ gui.button.sort=Trier
 gui.button.add=Ajouter
 gui.button.update=Mettre \u00e0 jour
 gui.button.delete=Effacer
+gui.button.copy=Copier
 
 gui.button.deleteRuleset=Effacer ce jeu de r\u00e8gle
 gui.button.replaceRuleset=Remplacer ce jeu de r\u00e8gle

--- a/arc-web/src/main/resources/global_fr.properties
+++ b/arc-web/src/main/resources/global_fr.properties
@@ -27,7 +27,7 @@ normManagement.structurize=Structuration
 normManagement.control=Contr\u00f4le
 normManagement.filter=Filtrage
 normManagement.mapmodel=Mapping
-normManagement.copyRules=Jeux de r\u00e8gles \u00e0 copier
+normManagement.copyRules=Jeu de r\u00e8gle \u00e0 copier
 
 gui.button.refresh=Rafra\u00eechir
 gui.button.see=Voir
@@ -41,7 +41,7 @@ gui.button.deleteRuleset=Effacer ce jeu de r\u00e8gle
 gui.button.replaceRuleset=Remplacer ce jeu de r\u00e8gle
 gui.button.generateRuleset=Pr\u00e9-g\u00e9n\u00e9rer les r\u00e8gles
 gui.button.downloadRuleset=T\u00e9l\u00e9charger les r\u00e8gles
-gui.button.importRuleset=Importer un jeu de r\u00e8gles
+gui.button.importRuleset=Importer un jeu de r\u00e8gle
 
 gui.button.downloadDatabase=T\u00e9l\u00e9charger DB
 gui.button.downloadFile=T\u00e9l\u00e9charger fichier

--- a/arc-web/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/arc-web/src/main/webapp/WEB-INF/applicationContext.xml
@@ -175,7 +175,6 @@
 		<aop:scoped-proxy />
 		<property name="pool" value="arc" />
 		<property name="sessionName" value="viewJeuxDeReglesCopie" />
-		<property name="title" value="Choix d'un jeux de règles" />
 		<property name="paginationSize" value="15" />
 	</bean>
 

--- a/arc-web/src/main/webapp/js/component.js
+++ b/arc-web/src/main/webapp/js/component.js
@@ -11,6 +11,7 @@
 //ICS:AjaxDataSelector;
 //Render:ConsoleIhm;
 //Render:FixedHeader;
+//Render:ChooseFileWithName;
 
 var fadeDelay=0, setTimeoutConst;
 
@@ -157,6 +158,15 @@ $(document).on('ready readyAgain',function() {
 		$('[name="consoleIhm"]').height(Math.max($('div[id^="viewPilotage"]').height(),$('div[id^="viewRapport"]').height())-50);
 	}
 
+/* Fix Bootstrap  not showing the file name with custom-file-input class.*/
+	if (configJS.indexOf("Render:ChooseFileWithName;"))
+	{
+		$('.custom-file-input').on('change', function(e){
+			var fileName = this.files[0].name;
+			var nextSibling = e.target.nextElementSibling;
+			nextSibling.innerText = fileName;
+		});
+	}
 
 
 	if (configJS.indexOf("ICS:AjaxDataSelector;")>-1)

--- a/arc-web/src/main/webapp/js/component.js
+++ b/arc-web/src/main/webapp/js/component.js
@@ -204,6 +204,7 @@ $(document).on('ready readyAgain',function() {
 		$('.datepicker').on('focus',function(){$(this).attr('m','js');});
 
 		$('select').on('change',function(){
+			$(this).css("background-color","#ffcccc");
 			$(this).attr('m','js');
 		});
 

--- a/arc-web/src/main/webapp/js/gererNorme.js
+++ b/arc-web/src/main/webapp/js/gererNorme.js
@@ -5,7 +5,8 @@ var configJS="Render:FixedHeader;" +
 		"IHM:TextareaHotkeys;" +
 		"IHM:TableMultiCheckbox;" +
 		"Render:AlertBox;" +
-		"IHM:Onglet;";
+		"IHM:Onglet;" + 
+		"Render:ChooseFileWithName;";
 
 $( document ).on('ready readyAgain',function() {
 	

--- a/arc-web/src/main/webapp/jsp/gererNorme.jsp
+++ b/arc-web/src/main/webapp/jsp/gererNorme.jsp
@@ -655,7 +655,7 @@
 														type="submit"
 														doAction="copieJeuxDeRegles"
 														scope="-viewJeuxDeReglesCopie;<s:property value="%{viewJeuxDeReglesCopie.customValues['SELECTED_RULESET_NAME']}"/>;"
-														value="Copier"
+														value="<s:text name="gui.button.copy"/>"
 													></input>
 												</s:param>
 

--- a/arc-web/src/main/webapp/jsp/gererNorme.jsp
+++ b/arc-web/src/main/webapp/jsp/gererNorme.jsp
@@ -502,6 +502,7 @@
 
 												<s:if test="viewFiltrage.content.lines.size()==0">
 													<input
+														class="btn btn-primary btn-sm"
 														id="viewFiltrage.creerNouveau"
 														type="submit"
 														doAction="preGenererRegleFiltrage"
@@ -586,6 +587,7 @@
 
 												<s:if test="viewMapping.content.lines.size()==0">
 													<input
+														class="btn btn-primary btn-sm"
 														id="viewMapping.creerNouveau"
 														type="submit"
 														doAction="preGenererRegleMapping"

--- a/arc-web/src/main/webapp/jsp/gererNorme.jsp
+++ b/arc-web/src/main/webapp/jsp/gererNorme.jsp
@@ -356,7 +356,7 @@
 												<div class="input-group my-3">
 													<div class="custom-file">
 														<input
-															name="fileUploadstructure"
+															name="fileUploadStructurize"
 															type="file"
 															class="custom-file-input"
 															id="inputGroupFilestructure"

--- a/arc-web/src/main/webapp/jsp/gererNorme.jsp
+++ b/arc-web/src/main/webapp/jsp/gererNorme.jsp
@@ -311,7 +311,7 @@
 														scope="viewChargement;"
 														multipart="true"
 													><span class="fa fa-upload">&nbsp;</span> <s:text
-															name="general.uploadFile"
+															name="gui.button.importRuleset"
 														/></button>
 												</div>
 											</div>
@@ -385,7 +385,7 @@
 															scope="viewNormage;"
 															multipart="true"
 														><span class="fa fa-upload">&nbsp;</span> <s:text
-																name="general.uploadFile"
+																name="gui.button.importRuleset"
 															/></button>
 													</div>
 												</div>
@@ -458,7 +458,7 @@
 															scope="viewControle;"
 															multipart="true"
 														><span class="fa fa-upload">&nbsp;</span> <s:text
-																name="general.uploadFile"
+																name="gui.button.importRuleset"
 															/></button>
 													</div>
 												</div>
@@ -542,7 +542,7 @@
 															scope="viewFiltrage;"
 															multipart="true"
 														><span class="fa fa-upload">&nbsp;</span> <s:text
-																name="general.uploadFile"
+																name="gui.button.importRuleset"
 															/></button>
 													</div>
 												</div>
@@ -627,7 +627,7 @@
 															scope="viewMapping;"
 															multipart="true"
 														><span class="fa fa-upload">&nbsp;</span> <s:text
-																name="general.uploadFile"
+																name="gui.button.importRuleset"
 															/></button>
 													</div>
 												</div>

--- a/arc-web/src/main/webapp/jsp/gererNorme.jsp
+++ b/arc-web/src/main/webapp/jsp/gererNorme.jsp
@@ -145,7 +145,17 @@
 								<s:param name="extraScopeAdd">-viewChargement;-viewNormage;-viewControle;-viewFiltrage;-viewMapping;-viewJeuxDeReglesCopie;viewModuleButtons;</s:param>
 								<s:param name="extraScopeUpdate">-viewChargement;-viewNormage;-viewControle;-viewFiltrage;-viewMapping;-viewJeuxDeReglesCopie;viewModuleButtons;</s:param>
 								<s:param name="extraScopeSee">viewChargement;-viewNormage;-viewControle;-viewFiltrage;-viewMapping;-viewJeuxDeReglesCopie;viewModuleButtons;</s:param>
-
+								<s:param name="otherButton">
+									<button
+										class="btn btn-primary btn-sm"
+										id="viewJeuxDeRegles.download"
+										type="submit"
+										doAction="downloadJeuxDeRegles"
+										ajax="false"
+									><span class="fa fa-download">&nbsp;</span> <s:text
+											name="gui.button.downloadRuleset"
+										/></button>
+								</s:param>
 							</s:include>
 						</div>
 					</div>

--- a/arc-web/src/main/webapp/jsp/tiles/templateVObject.jsp
+++ b/arc-web/src/main/webapp/jsp/tiles/templateVObject.jsp
@@ -243,12 +243,28 @@
 																></s:select>
 															</s:else>
 														</s:if> <s:else>
-															<s:textarea
-																name="%{#view.sessionName}.content.lines[%{#incr1.index}].data[%{#incr2.index}]"
-																value="%{#view.content.lines[#incr1.index].data[#incr2.index]}"
-																theme="simple"
-																readonly="true"
-															></s:textarea>
+															<s:if
+																test='%{"select".equals(#view.guiColumnsType[#incr2.index])}'
+															>
+															<s:select
+																class="w-100"
+																	list="%{#view.guiSelectedColumns[#incr2.index]}"
+																	name="%{#view.sessionName}.content.lines[%{#incr1.index}].data[%{#incr2.index}]"
+																	value="%{#view.content.lines[#incr1.index].data[#incr2.index]}"
+																	theme="simple"
+																	disabled="true"
+																></s:select>
+																<s:hidden name="%{#view.sessionName}.content.lines[%{#incr1.index}].data[%{#incr2.index}]"
+																	value="%{#view.content.lines[#incr1.index].data[#incr2.index]}" />
+															</s:if>
+															<s:else>
+																<s:textarea
+																	name="%{#view.sessionName}.content.lines[%{#incr1.index}].data[%{#incr2.index}]"
+																	value="%{#view.content.lines[#incr1.index].data[#incr2.index]}"
+																	theme="simple"
+																	readonly="true"
+																></s:textarea>
+															</s:else>
 														</s:else></td>
 												</s:if>
 												<s:else>


### PR DESCRIPTION
This fixes multiples issues in the norm management page.

Some are related to the import/export options: 
* the export button was missing
* the file import input was broken for some categories

Others to the copy ruleset function: 
* the request code was broken for some categories
* the copy ruleset table lacked translation
* some style was missing

The truncate function was also broken for some categories (missing Java methods).

Two fixes have a larger impact:
* select fields were not  visually marked as changed when changed (turning red). This PR fixes this on all pages.
* the file input using Bootstrap did not show the filename or any indication that a file had been picked. An new module (Render:ChooseFileWithName) needs to be added to fix this on other pages.