### PR TITLE
Use openjdk11 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk8
+jdk: openjdk11
 addons:
   sonarcloud:
     organization: "inseefr"


### PR DESCRIPTION
Github issue #58 : Sonarcloud is deprecating jdk8.